### PR TITLE
3.0.0 swift5 bounding rect fix update

### DIFF
--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -251,10 +251,13 @@ open class MessageSizeCalculator: CellSizeCalculator {
             var isPartiallyUnderlined = false
             attributedText.enumerateAttribute(.underlineStyle,
                                               in: fullRange) { value, range, stop in
-                                                if fullRange != range {
+                                                if let underlineValue = value as? Int,
+                                                    NSUnderlineStyle.single == NSUnderlineStyle(rawValue: underlineValue),
+                                                    !NSEqualRanges(fullRange, range) {
                                                     isPartiallyUnderlined = true
                                                     stop.pointee = true
                                                 }
+
             }
             if isPartiallyUnderlined {
                 let tempMutableCopy = NSMutableAttributedString(attributedString: attributedText)

--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -248,32 +248,24 @@ open class MessageSizeCalculator: CellSizeCalculator {
         let adjustedRect: CGRect
         if #available(iOS 13, *) {
             let fullRange = NSRange(0..<attributedText.length)
-            var isPartiallyUnderlined = false
-            attributedText.enumerateAttribute(.underlineStyle,
-                                              in: fullRange) { value, range, stop in
-                                                if let underlineValue = value as? Int,
-                                                    NSUnderlineStyle.single == NSUnderlineStyle(rawValue: underlineValue),
-                                                    !NSEqualRanges(fullRange, range) {
-                                                    isPartiallyUnderlined = true
-                                                    stop.pointee = true
-                                                }
-
+            var isPartiallyAttributed = false
+            attributedText.enumerateAttributes(in: fullRange) { value, range, stop in
+                if !NSEqualRanges(fullRange, range) {
+                    isPartiallyAttributed = true
+                    stop.pointee = true
+                }
             }
-            if isPartiallyUnderlined {
-                let tempMutableCopy = NSMutableAttributedString(attributedString: attributedText)
-                tempMutableCopy.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: fullRange)
-                adjustedRect = tempMutableCopy.boundingRect(with: constraintBox,
-                                                            options: [.usesLineFragmentOrigin, .usesFontLeading],
-                                                            context: nil)
-            } else {
-                adjustedRect = attributedText.boundingRect(with: constraintBox,
-                                                           options: [.usesLineFragmentOrigin, .usesFontLeading],
-                                                           context: nil)
+            var options: NSStringDrawingOptions = [.usesLineFragmentOrigin, .usesFontLeading]
+            if isPartiallyAttributed {
+                options.formUnion(NSStringDrawingOptions.usesDeviceMetrics)
             }
+            adjustedRect = attributedText.boundingRect(with: constraintBox,
+                                                                            options: options,
+                                                                            context: nil)
         } else {
             adjustedRect = attributedText.boundingRect(with: constraintBox,
-                                                       options: [.usesLineFragmentOrigin, .usesFontLeading],
-                                                       context: nil)
+                                                                            options: [.usesLineFragmentOrigin, .usesFontLeading],
+                                                                            context: nil)
         }
 
         return adjustedRect.size


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
…
Attributed text bounding text is not providing correct size so used string bounding rect method to get the size with the attributes

Does this close any currently open issues?
------------------------------------------
…
Fix bounding rect text cut off issues on iOS 13.0

Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**MessageKit Version:** …


